### PR TITLE
Switching conda->pip avoids widespread package downgrades

### DIFF
--- a/install-nbgrader.sh
+++ b/install-nbgrader.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -x
-conda install nbgrader=0.6.0
+pip install nbgrader==0.6.0
 
 jupyter nbextension install --symlink --sys-prefix --py nbgrader
 jupyter nbextension enable --sys-prefix --py nbgrader


### PR DESCRIPTION
Making this change, along with removing hardcoded package installs from datascience-notebook, maintains scipy at a modern version ##